### PR TITLE
Content for the Selectors section

### DIFF
--- a/act-framework.bs
+++ b/act-framework.bs
@@ -55,7 +55,9 @@ ACT Test Procedure {#test-proc}
 Selector {#test-proc-selector}
 --------
 
-Editor note: This section will describe how, given a certain input type (see above), the elements or components are located that can be tested using the rule, and how the author of a rule should describe this.
+A selector is a boolean predicate that takes an element or component in the set represented in the input data and unambiguously tests whether the element or component matches the selector or not. In an ACT Rule, a selector is applied to the entire input data to filter it into a set of elements or components to be evaluated with the test procedure.
+
+Selector syntax depends on the input type. When the input data is an HTML document or set of elements, the selector must be a CSS selector. When a formal selector syntax is not available for the input type, the selector may be described unambiguously in plain English.
 
 
 Test Cases {#test-proc-cases}


### PR DESCRIPTION
A couple comments:

- I added a definition of a _selector_, adapted from the definition in [CSS Selectors Level 4](https://drafts.csswg.org/selectors-4/#context).
- I kept the concept of _element or component_ from the placeholder description, but we might want to just say _element_?
- For HTML input data, I suggest we **must** use CSS selectors. Using XPath on DOM is not properly specified and would be limited to XPath 1.0. XPath 2.0 or 3.0 could be used on static XML serialization of HTML, but I don't think it is practically very relevant. (disclaimer: I actually _love_ XPath).
- I find this section depends a lot on what we'll describe in the "ACT Input Data" section, which is not yet specified. For now, I assumed we can speak of "HTML input data" for any kind of HTML, document or fragment, even when annotated with computed CSS properties.
- I haven't actually tried to process the text with Bikeshed, sorry if there are any glitches.
- we should add a ref to a CSS Selectors spec (I suppose Level 3?).