### PR TITLE
Update Selector definition

### DIFF
--- a/act-framework.bs
+++ b/act-framework.bs
@@ -63,7 +63,7 @@ ACT Test Procedure {#test-proc}
 Selector {#test-proc-selector}
 --------
 
-A selector is a pattern used to select element(s) in an HTML document or node(s) in the DOM tree. In an ACT Rule, a selector is applied to the entire input data to filter it into a set of elements or nodes to be evaluated against the test procedure.
+A selector is a pattern that is used as a condition to filter input data to be evaluated against the test procedure. For example, finding all  nodes in the DOM tree, or finding tags that are incorrectly closed in an HTML document.
 
 Selector syntax depends on the input type. When the input data is an HTML document or set of elements, the selector must be a CSS selector. When a formal selector syntax is not available for the input type, the selector may be described unambiguously in plain English.
 

--- a/act-framework.bs
+++ b/act-framework.bs
@@ -63,7 +63,7 @@ ACT Test Procedure {#test-proc}
 Selector {#test-proc-selector}
 --------
 
-A selector is a boolean predicate that takes an element or component in the set represented in the input data and unambiguously tests whether the element or component matches the selector or not. In an ACT Rule, a selector is applied to the entire input data to filter it into a set of elements or components to be evaluated with the test procedure.
+A selector is a pattern used to select element(s) in an HTML document or node(s) in the DOM tree. In an ACT Rule, a selector is applied to the entire input data to filter it into a set of elements or nodes to be evaluated against the test procedure.
 
 Selector syntax depends on the input type. When the input data is an HTML document or set of elements, the selector must be a CSS selector. When a formal selector syntax is not available for the input type, the selector may be described unambiguously in plain English.
 


### PR DESCRIPTION
The consensus from the 12/14/16 meeting was to simplify this definition
to use plainer text. As well, Alistair asks to be careful about the use
of element vs. node.

Some simplified text suggestions:
"selectors are patterns used to select the element(s) you want to work
with." - Alistair
From CSS 3 Selectors, Selectors are patterns that match against elements
in a tree, and as such form one of several technologies that can be used
to select nodes in an XML document. Selectors have been optimized for
use with HTML and XML, and are designed to be usable in
performance-critical code.
From w3 Schools: In CSS, selectors are patterns used to select the
element(s) you want to style.