### PR TITLE
Update Accessibility Support href to match heading id

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -45,7 +45,7 @@ Each ACT Rule MUST provide the following items written in plain language:
 * [Rule Description](#structure-description)
 * [Accessibility Requirements](#structure-accessibility-requirements)
 * [Limitations, Assumptions or Exceptions](#structure-limitations-assumptions-exceptions), if any
-* [Accessibility Support](#structure-acc-supp) (optional)
+* [Accessibility Support](#acc-support) (optional)
 * [Test Subject Type](#input-types)
 * [Test Procedure](#test-proc)
 


### PR DESCRIPTION
Bikeshed error revealed a mismatch in href and heading id. Updated to match #acc-support