### PR TITLE
Update "8. Aspects under Test"

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -113,29 +113,29 @@ A list of common aspects for reference in ACT rules can be found in [Common Aspe
 
 <div class=example>
   <p>Test aspects for a rule that checks if images have an accessible name:</p>
-  <li>
-    <ul>DOM Tree</ul>
-    <ul>CSS Styling</ul>
-  </li>
+  <ul>
+    <li>DOM Tree</li>
+    <li>CSS Styling</li>
+  </ul>
 </div>
 
 <div class=example>
   <p>Test aspects for a rule that checks if a transcript is available for videos:</p>
-    <li>
-    <ul>DOM Tree</ul
-    <ul>CSS Styling</ul
-    <ul>Audio output</ul
-    <ul>Visual output</ul
-  </li>
+  <ul>
+    <li>DOM Tree</li>
+    <li>CSS Styling</li>
+    <li>Audio output</li>
+    <li>Visual output</li>
+  </ul>
 </div>
 
 <div class=example>
   <p>Test aspects for a rule that checks for use of (language specific) generic link texts like "click here" and "more":</p>
-    <li>
-    <ul>DOM Tree</ul
-    <ul>CSS Styling</ul
-    <ul>Language</ul
-  </li>
+    <ul>
+    <li>DOM Tree</li>
+    <li>CSS Styling</li>
+    <li>Language</li>
+  </ul>
 </div>
 
 Test Definition (Atomic rules only) {#test-def}

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -109,37 +109,25 @@ An aspect is a distinct part of the [test subject](#output-test-subject) or its 
 
 An atomic rule MUST include a description of all the aspects under test by the rule. Each aspect MUST be discrete with no overlap between the aspects. Some aspects are already well defined within the context of web content, such as HTTP messages, DOM tree, and CSS styling [[CSS2]], and do not warrant a detailed description. Other aspects may not be well defined or even specific to web content. In these cases, an ACT Rule SHOULD include either a detailed description of the aspect in question or a reference to that description.
 
+A list of common aspects for reference in ACT rules can be found in [Common Aspects under Test](#).
 
-Common Aspects {#input-aspects-common}
---------------------------------------
+<div class=example>
+  <p>Test aspects for a rule that checks if images have an accessible name:</p>
+  <li>
+    <ul>DOM Tree</ul>
+    <ul>CSS Styling</ul>
+  </li>
+</div>
 
-### HTTP Messages ### {#input-aspects-http}
-
-The HTTP messages [[http11]] exchanged between a client and a server as part of requesting a web page may be of interest to ACT Rules. For example, analyzing HTTP messages to perform validation of HTTP headers or unparsed HTML [[HTML]] and CSS [[CSS2]].
-
-### DOM Tree ### {#input-aspects-dom}
-
-The DOM [[DOM]] tree constructed from parsing HTML [[HTML]], and optionally executing DOM manipulating JavaScript, may be of interest to ACT Rules to test the structure of web pages. In the DOM tree, information about individual elements of a web page, and their relations, becomes available.
-
-The means by which the DOM tree is constructed, be it by a web browser or not, is not of importance as long as the construction follows the [Document Object Model](https://dom.spec.whatwg.org) [[DOM]].
-
-### CSS Styling ### {#input-aspects-css}
-
-The computed CSS [[CSS2]] styling resulting from parsing CSS and applying it to the DOM [[DOM]] may be of interest to ACT Rules that wish to test the web page as presented to the user. Through CSS styling, information about the position, the foreground and background colors, the visibility, and more, of elements becomes available.
-
-The means by which the CSS styling is computed, be it by a web browser or not, is not of importance as long as the computation follows any applicable specifications that might exist, such as the [CSS Object Model](https://www.w3.org/TR/cssom/) [[CSSOM]].
-
-### Accessibility Tree ### {#input-aspects-accessibility}
-
-The accessibility tree constructed from extracting information from both the DOM [[DOM]] tree and the CSS [[CSS2]] styling may be of interest to ACT Rules. This can be used to test the web page as presented to assistive technologies such as screen readers. Through the accessibility tree, information about the semantic roles, accessible names and descriptions, and more, of elements becomes available.
-
-The means by which the accessibility tree is constructed, be it by a web browser or not, is not of importance as long as the construction follows any applicable specifications that might exist, such as the [Core Accessibility API Mappings 1.1](https://www.w3.org/TR/core-aam-1.1/) [[CORE-AAM-1.1]].
-
-### Language ### {#input-aspects-text}
-
-Language, either written or spoken, contained in nodes of the DOM [[DOM]] or accessibility trees may be of interest to ACT Rules that intend to test things like complexity or intention of the language. For example, an ACT Rule might test that paragraphs of text within the DOM tree do not exceed a certain readability score or that the text alternative of an image provides a sufficient description.
-
-The means by which the language is assessed, whether by a person or a machine, is not of importance as long as the assessment meets the criteria defined in [[wcag2-tech-req#humantestable]] [[WCAG]].
+<div class=example>
+  <p>Test aspects for a rule that checks if a transcript is available for videos:</p>
+    <li>
+    <ul>DOM Tree</ul
+    <ul>CSS Styling</ul
+    <ul>Audio output</ul
+    <ul>Visual output</ul
+  </li>
+</div>
 
 
 Test Definition (Atomic rules only) {#test-def}

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -109,7 +109,7 @@ An aspect is a distinct part of the [test subject](#output-test-subject) or its 
 
 An atomic rule MUST include a description of all the aspects under test by the rule. Each aspect MUST be discrete with no overlap between the aspects. Some aspects are already well defined within the context of web content, such as HTTP messages, DOM tree, and CSS styling [[CSS2]], and do not warrant a detailed description. Other aspects may not be well defined or even specific to web content. In these cases, an ACT Rule SHOULD include either a detailed description of the aspect in question or a reference to that description.
 
-A list of common aspects for reference in ACT rules can be found in [Common Aspects under Test](#).
+A list of common aspects for reference in ACT rules can be found in [Common Aspects under Test](https://w3c.github.io/wcag-act/NOTE-act-rules-common-aspects.html).
 
 <div class=example>
   <p>Test aspects for a rule that checks if images have an accessible name:</p>

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -129,6 +129,14 @@ A list of common aspects for reference in ACT rules can be found in [Common Aspe
   </li>
 </div>
 
+<div class=example>
+  <p>Test aspects for a rule that checks for use of (language specific) generic link texts like "click here" and "more":</p>
+    <li>
+    <ul>DOM Tree</ul
+    <ul>CSS Styling</ul
+    <ul>Language</ul
+  </li>
+</div>
 
 Test Definition (Atomic rules only) {#test-def}
 ===============================================


### PR DESCRIPTION
Remove "8.1 Common Aspects" to move it to a working group note. Insert link and examples in "8. Aspects under Test" instead.
In answer to https://github.com/w3c/wcag-act/issues/233.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/annethyme/wcag-act/pull/242.html" title="Last updated on Sep 13, 2018, 1:39 PM GMT (566ab45)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/242/54fc1ba...annethyme:566ab45.html" title="Last updated on Sep 13, 2018, 1:39 PM GMT (566ab45)">Diff</a>