### PR TITLE
Fix the PR Preview config

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,4 +1,7 @@
 {
     "src_file": "act-rules-format.bs",
-    "type": "bikeshed"
+    "type": "bikeshed",
+    "params": {
+        "force": 1
+    }
 }


### PR DESCRIPTION
This PR "fixes" the PR Preview config by adding the `force` param to generate the spec even when Bikeshed raises errors.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rdeltour/wcag-act/pull/254.html" title="Last updated on Sep 6, 2018, 7:08 AM GMT (3379077)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/254/1f76e23...rdeltour:3379077.html" title="Last updated on Sep 6, 2018, 7:08 AM GMT (3379077)">Diff</a>