### PR TITLE
Remove formal syntax

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -202,7 +202,7 @@ Applicability for Atomic Rules {#applicability-atomic}
 
 The applicability section is a required part of an [=atomic rule=]. It MUST contain a precise description of the parts of the [=test subject=] to which the rule applies. For example, specific nodes in the DOM [[DOM]] tree, or tags that are incorrectly closed in an HTML [[HTML]] document. These are known as the [=test targets=]. The applicability MUST only use information provided through [test aspects](#input-aspects) of the same rule. No other information can be used in the applicability.
 
-Applicability MUST be described objectively, unambiguously and in plain language. When a formal syntax, such as a [CSS selector](https://www.w3.org/TR/selectors-3/) [[css3-selectors]] or [XML Path Language](https://www.w3.org/TR/xpath/) [[XPATH]], can be used, that (part of the) applicability MAY use that syntax in addition to the plain language description.
+Applicability MUST be described objectively, unambiguously and in plain language.
 
 An objective description is one that can be resolved without uncertainty, in a given technology. Examples of objective properties in HTML are element names, their computed role, the spacing between two elements, etc. Subjective properties on the other hand, are concepts like decorative, navigation mechanism and pre-recorded. Even concepts like headings and images can be misunderstood. For example, describing that the rule examines the tag name, the accessibility role, or the element's purpose on the web page. The latter of which is almost impossible to define objectively. When used in applicability, potentially ambiguous concepts MUST be defined objectively. This definition can be part of a larger glossary shared between rules.
 


### PR DESCRIPTION
Addressing Issue 294 from TPAC discussion to remove formal syntax in 10.1, "When a formal syntax, such as a CSS selector [css3-selectors] or XML Path Language [XPATH], can be used, that (part of the) applicability MAY use that syntax in addition to the plain language description."


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/pull/304.html" title="Last updated on Nov 15, 2018, 3:08 PM GMT (2a21fc5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/304/809e9f5...2a21fc5.html" title="Last updated on Nov 15, 2018, 3:08 PM GMT (2a21fc5)">Diff</a>