### PR TITLE
"Optional items" section + renaming "Assumptions"

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -73,7 +73,7 @@ An ACT Rule MUST consist of at least the following items:
 * [Accessibility Support](#accessibility-support)
 * [Test Cases](#test-cases)
 * [Change Log](#change-log)
-* [Issues List](#issues-list) (optional)
+* [Issues List](#issues-list)
 * [Acknowledgements](#acknowledgements) (optional)
 * [Background](#background) (optional)
 * ACT Rules Format [=outcome=] definition
@@ -130,8 +130,6 @@ An ACT Rule SHOULD list an identifier and reference for each accessibility requi
 </div>
 
 One reason why an [=atomic rule=] might not list accessibility requirements is because it is part of a [=composite rule=], and only a `failed` [=outcome=] in the composite rule would mean not satisfying the accessibility requirement. Another reason might be that an ACT Rule is designed to evaluate a best practice that is not part of any accessibility standard.
-
-This section MAY be left blank.
 
 Accessibility Requirements Mapping {#accessibility-requirements-mapping}
 ------------------------------------------------------------------------
@@ -292,7 +290,7 @@ An ACT Rule MUST list any assumptions, limitations or any exceptions for the eva
 
 Sometimes there are multiple plausible ways that an accessibility requirement can be interpreted. For instance, it is not immediately obvious if emoji characters are "text" or "non-text content" under WCAG 2.1. Whatever the interpretation is, this MUST be documented in the rule.
 
-This section MAY be left blank.
+While this item MUST be included in the ACT Rule, it MAY be empty when there are no known assumptions, limitations or exceptions.
 
 Accessibility Support {#accessibility-support}
 ==============================================
@@ -300,7 +298,7 @@ Content can be designed to rely on the support for particular accessibility feat
  
 An ACT Rule MUST include known limitations on accessibility support. For example, an atomic rule that checks for a particular accessibility feature that is known not to be widely supported by assistive technologies and web browsers, or a composite rule that includes atomic rules with known accessibility support limitations.
 
-This section MAY be left blank.
+While this item MUST be included in the ACT Rule, it MAY be empty.
  
 <div class=note>
   **Note:** WCAG Evaluation Methodology (WCAG-EM) provides guidance on defining an [accessibility support baseline](https://www.w3.org/TR/WCAG-EM/#step1c) for test scenarios, which can help users of ACT Rules to select the appropriate rules for their own circumstance.
@@ -325,7 +323,7 @@ Each new release of an ACT Rule MUST be identifiable with either a date or a ver
 </div>
 
 
-Issues List (optional) {#issues-list}
+Issues List {#issues-list}
 =====================================
 
 An ACT Rule MUST include a list or a reference to a list of any known issues. The issues list MUST be used to record cases where the [=outcome=] of an ACT Rule was `failed` where it ought to have been `passed` or `inapplicable`, or vice versa. There are several reasons why this might occur, including:
@@ -336,7 +334,7 @@ An ACT Rule MUST include a list or a reference to a list of any known issues. Th
 
 The issues list serves two purposes. For users of ACT Rules, the issues list gives insight into why an inaccurate result occurred, as well as provide confidence in the result of that rule. For the designer of the rule, the issues list is also useful to plan future updates to the rule. In a new version of the rule, resolved issues would be moved to the change log.
 
-This section can be left blank.
+While this item MUST be included in the ACT Rule document, it MAY be empty.
 
 Acknowledgements (optional) {#acknowledgements}
 ===============================================

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -328,7 +328,7 @@ An ACT Rule SHOULD include known limitations on accessibility support. For examp
 </div>
 
 
-Background {#Background}
+Background {#background}
 -----------------------
 An ACT Rule can contain information about the background for the development of the rule, or references to relevant reading. The relationship to the relevant reading should be specified. Examples of relevant background references for a rule for a WCAG [[WCAG]] success criterion could be [Understanding documents](https://www.w3.org/WAI/WCAG21/Understanding/), [WCAG Techniques](https://www.w3.org/WAI/WCAG21/Techniques/), or WAI-ARIA [[WAI-ARIA]], CSS [[CSS]], or HTML [[HTML]] specifications.
 

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -131,6 +131,7 @@ An ACT Rule SHOULD list an identifier and reference for each accessibility requi
 
 One reason why an [=atomic rule=] might not list accessibility requirements is because it is part of a [=composite rule=], and only a `failed` [=outcome=] in the composite rule would mean not satisfying the accessibility requirement. Another reason might be that an ACT Rule is designed to evaluate a best practice that is not part of any accessibility standard.
 
+This section can be left blank.
 
 Accessibility Requirements Mapping {#accessibility-requirements-mapping}
 ------------------------------------------------------------------------
@@ -291,12 +292,15 @@ An ACT Rule MUST list any assumptions, limitations or any exceptions for the eva
 
 Sometimes there are multiple plausible ways that an accessibility requirement can be interpreted. For instance, it is not immediately obvious if emoji characters are "text" or "non-text content" under WCAG 2.1. Whatever the interpretation is, this MUST be documented in the rule.
 
+This section can be left blank.
 
 Accessibility Support {#accessibility-support}
 ==============================================
 Content can be designed to rely on the support for particular accessibility features by different assistive technologies and user agents. For example, content using a particular WAI-ARIA [[WAI-ARIA]] feature relies on that feature to be supported by assistive technologies and user agents. This content would not work for assistive technologies and user agents that do not support WAI-ARIA. WCAG [[WCAG]] provides a definition for [accessibility supported](https://www.w3.org/TR/WCAG20/#accessibility-supporteddef) use of a Web technology.
  
 An ACT Rule MUST include known limitations on accessibility support. For example, an atomic rule that checks for a particular accessibility feature that is known not to be widely supported by assistive technologies and web browsers, or a composite rule that includes atomic rules with known accessibility support limitations.
+
+This section can be left blank.
  
 <div class=note>
   **Note:** WCAG Evaluation Methodology (WCAG-EM) provides guidance on defining an [accessibility support baseline](https://www.w3.org/TR/WCAG-EM/#step1c) for test scenarios, which can help users of ACT Rules to select the appropriate rules for their own circumstance.
@@ -332,6 +336,7 @@ An ACT Rule MUST include a list or a reference to a list of any known issues. Th
 
 The issues list serves two purposes. For users of ACT Rules, the issues list gives insight into why an inaccurate result occurred, as well as provide confidence in the result of that rule. For the designer of the rule, the issues list is also useful to plan future updates to the rule. In a new version of the rule, resolved issues would be moved to the change log.
 
+This section can be left blank.
 
 Acknowledgements (optional) {#acknowledgements}
 ===============================================

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -69,10 +69,15 @@ An ACT Rule MUST consist of the following items:
 * [Aspects Under Test](#input-aspects) (for atomic rules) OR [Atomic Rules List](#atomic-rules-list) (for composite rules)
 * [Applicability](#applicability)
 * [Expectations](#expectations)
-* [Limitations, Assumptions or Exceptions](#limitations-assumptions-exceptions), if any
-* [Accessibility Support](#accessibility-support) (optional)
+* [Assumptions](#assumptions), if any
 * [Test Cases](#test-cases)
 * ACT Rules Format [=outcome=] definition
+
+An ACT Rule MAY include one or more of the following [optional items](#optional-items)
+ 
+* Accessibility Support {#accessibility-support} (optional)
+* Background {#Background} (optional)
+* Acknowledgements {#acknowledgements} (optional)
 
 ACT Rules MUST be written in a format that conforms to the Web Content Accessibility Guidelines [[WCAG]] or a comparable accessibility standard. ACT Rule [test cases](#test-cases) are allowed to contain inaccessible content. If any test case contains accessibility issues listed in [WCAG 2.1 Section 5.2.5 Non-Interference](https://www.w3.org/TR/WCAG21/#cc5), users MUST be warned of this in advance. Using an accessible format supports people with disabilities. It also makes internationalization of ACT Rules easier.
 
@@ -280,10 +285,10 @@ When all expectations are true for a test target, the test target `passed` the r
 </div>
 
 
-Limitations, Assumptions or Exceptions {#limitations-assumptions-exceptions}
-======================================================================================
+Assumptions {#assumptions}
+==========================
 
-An ACT Rule MUST list any limitations, assumptions or any exceptions for the evaluation, the test environment, technologies being used or the subject being tested. For example, a rule that would partially test <a href="https://www.w3.org/WAI/WCAG20/quickref/#visual-audio-contrast-contrast" target="_blank">WCAG 2.0 Success Criterion 1.4.3 Contrast (Minimum)</a> based on the inspection of CSS properties could state that it is only applicable to HTML text content stylable with CSS, and that the rule does not support images of text.
+An ACT Rule MUST list any assumptions, limitations or any exceptions for the evaluation, the test environment, technologies being used or the subject being tested. For example, a rule that would partially test <a href="https://www.w3.org/WAI/WCAG20/quickref/#visual-audio-contrast-contrast" target="_blank">WCAG 2.0 Success Criterion 1.4.3 Contrast (Minimum)</a> based on the inspection of CSS properties could state that it is only applicable to HTML text content stylable with CSS, and that the rule does not support images of text.
 
 Sometimes there are multiple plausible ways that an accessibility requirement can be interpreted. For instance, it is not immediately obvious if emoji characters are "text" or "non-text content" under WCAG 2.1. Whatever the interpretation is, this MUST be documented in the rule.
 
@@ -306,6 +311,37 @@ Test Cases {#test-cases}
 Test cases are (snippets of) content that can be used to validate the implementation of ACT Rules. Each rule MUST have one or more test cases for `passed`, `failed`, and `inapplicable` [=outcome=]. A test case consists of two pieces of data, a snippet of each [test aspect](#input-aspects) for a rule, and the expected result from evaluating that rule. Test cases serve two functions, firstly as example scenarios for readers to understand when a rule passes, when it fails, and when it is inapplicable. It also serves developers and users of accessibility testing tools and methodologies to validate that a rule is correctly implemented.
 
 
+Optional items {#optional-items}
+================================
+
+An ACT Rule can contain additional information that is useful, but not critical, for the reader to understand the background and context of a rule, or any information that is relevant. This can include, but is not limited to, one or more of the following:
+
+
+Accessibility Support {#accessibility-support}
+----------------------------------------------
+Content can be designed to rely on the support for particular accessibility features by different assistive technologies and user agents. For example, content using a particular WAI-ARIA [[WAI-ARIA]] feature relies on that feature to be supported by assistive technologies and user agents. This content would not work for assistive technologies and user agents that do not support WAI-ARIA. WCAG [[WCAG]] provides a definition for [accessibility supported](https://www.w3.org/TR/WCAG20/#accessibility-supporteddef) use of a Web technology.
+ 
+An ACT Rule SHOULD include known limitations on accessibility support. For example, an atomic rule that checks for a particular accessibility feature that is known not to be widely supported by assistive technologies and web browsers, or a composite rule that includes atomic rules with known accessibility support limitations.
+ 
+<div class=note>
+  **Note:** WCAG Evaluation Methodology (WCAG-EM) provides guidance on defining an [accessibility support baseline](https://www.w3.org/TR/WCAG-EM/#step1c) for test scenarios, which can help users of ACT Rules to select the appropriate rules for their own circumstance.
+</div>
+
+
+Background {#Background}
+-----------------------
+An ACT Rule can contain information about the background for the development of the rule, or references to relevant reading. The relationship to the relevant reading should be specified. Examples of relevant background references for a rule for a WCAG [[WCAG]] success criterion could be [Understanding documents](https://www.w3.org/WAI/WCAG21/Understanding/), [WCAG Techniques](https://www.w3.org/WAI/WCAG21/Techniques/), or WAI-ARIA [[WAI-ARIA]], CSS [[CSS]], or HTML [[HTML]] specifications.
+
+
+Acknowledgements {#acknowledgements}
+------------------------------------
+
+An ACT Rule can contain acknowledgements. This may include, but is not limited to:
+* List of rule authors
+* List of rule reviewers/contributors
+* Funding or other support
+ 
+ 
 Update Management {#updates}
 ============================
 

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -341,7 +341,7 @@ This section can be left blank.
 Acknowledgements (optional) {#acknowledgements}
 ===============================================
 
-An ACT Rule MAY contain acknowledgements. This may include, but is not limited to:
+An ACT Rule MAY contain acknowledgements. This can include, but is not limited to:
 * List of rule authors
 * List of rule reviewers/contributors
 * Funding or other support

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -71,13 +71,15 @@ An ACT Rule MUST consist of the following items:
 * [Expectations](#expectations)
 * [Assumptions](#assumptions), if any
 * [Test Cases](#test-cases)
+* [Change Log](#change-log)
 * ACT Rules Format [=outcome=] definition
 
 An ACT Rule MAY include one or more of the following [optional items](#optional-items):
  
-* Accessibility Support {#accessibility-support} (optional)
-* Background {#Background} (optional)
-* Acknowledgements {#acknowledgements} (optional)
+* [Accessibility Support](#accessibility-support) (optional)
+* [Acknowledgements](#acknowledgements) (optional)
+* [Background](#background) (optional)
+* [Issues List](#issues-list)
 
 ACT Rules MUST be written in a format that conforms to the Web Content Accessibility Guidelines [[WCAG]] or a comparable accessibility standard. ACT Rule [test cases](#test-cases) are allowed to contain inaccessible content. If any test case contains accessibility issues listed in [WCAG 2.1 Section 5.2.5 Non-Interference](https://www.w3.org/TR/WCAG21/#cc5), users MUST be warned of this in advance. Using an accessible format supports people with disabilities. It also makes internationalization of ACT Rules easier.
 
@@ -293,22 +295,22 @@ An ACT Rule MUST list any assumptions, limitations or any exceptions for the eva
 Sometimes there are multiple plausible ways that an accessibility requirement can be interpreted. For instance, it is not immediately obvious if emoji characters are "text" or "non-text content" under WCAG 2.1. Whatever the interpretation is, this MUST be documented in the rule.
 
 
-Accessibility Support {#accessibility-support}
-====================================
-
-Content can be designed to rely on the support for particular accessibility features by different assistive technologies and user agents. For example, content using a particular WAI-ARIA [[WAI-ARIA]] feature relies on that feature to be supported by assistive technologies and user agents. This content would not work for assistive technologies and user agents that do not support WAI-ARIA. WCAG [[WCAG]] provides a definition for [accessibility supported](https://www.w3.org/TR/WCAG20/#accessibility-supporteddef) use of a Web technology.
-
-An ACT Rule SHOULD include known limitations on accessibility support. For example, an atomic rule that checks for a particular accessibility feature that is known not to be widely supported by assistive technologies and web browsers, or a composite rule that includes atomic rules with known accessibility support limitations.
-
-<div class=note>
-  **Note:** WCAG Evaluation Methodology (WCAG-EM) provides guidance on defining an [accessibility support baseline](https://www.w3.org/TR/WCAG-EM/#step1c) for test scenarios, which can help users of ACT Rules to select the appropriate rules for their own circumstance.
-</div>
-
-
 Test Cases {#test-cases}
 ========================
 
 Test cases are (snippets of) content that can be used to validate the implementation of ACT Rules. Each rule MUST have one or more test cases for `passed`, `failed`, and `inapplicable` [=outcome=]. A test case consists of two pieces of data, a snippet of each [test aspect](#input-aspects) for a rule, and the expected result from evaluating that rule. Test cases serve two functions, firstly as example scenarios for readers to understand when a rule passes, when it fails, and when it is inapplicable. It also serves developers and users of accessibility testing tools and methodologies to validate that a rule is correctly implemented.
+
+
+Change Log {#changes-log}
+=============================
+
+It is important to keep track of changes to the ACT Rules so that users of the rules can understand if changes in test results are due to changes in the rules used when performing the tests, or from changes in the content itself. All changes to an ACT Rule that can change the [=outcome=] of a evaluation MUST be recorded in a change log. The change log can either be part of the rule document itself or be referenced from it.
+
+Each new release of an ACT Rule MUST be identifiable with either a date or a version number. Additionally, a reference to the previous version of that rule MUST be available. For extensive changes, a new rule SHOULD be created and the old rule SHOULD be deprecated.
+
+<div class=example>
+  **Example**: An example of when a new rule ought to be created is when a rule that tests for the use of a `blink` element changes to instead look for any animated style changes. This potentially adds several new failures that were previously out of scope. Using that same rule as an example, adding an exception to allow `blink` elements positioned off screen can be done by updating the existing rule.
+</div>
 
 
 Optional items {#optional-items}
@@ -328,11 +330,6 @@ An ACT Rule SHOULD include known limitations on accessibility support. For examp
 </div>
 
 
-Background {#background}
------------------------
-An ACT Rule can contain information about the background for the development of the rule, or references to relevant reading. The relationship to the relevant reading should be specified. Examples of relevant background references for a rule for a WCAG [[WCAG]] success criterion could be [Understanding documents](https://www.w3.org/WAI/WCAG21/Understanding/), [WCAG Techniques](https://www.w3.org/WAI/WCAG21/Techniques/), or WAI-ARIA [[WAI-ARIA]], CSS [[CSS]], or HTML [[HTML]] specifications.
-
-
 Acknowledgements {#acknowledgements}
 ------------------------------------
 
@@ -340,24 +337,14 @@ An ACT Rule can contain acknowledgements. This may include, but is not limited t
 * List of rule authors
 * List of rule reviewers/contributors
 * Funding or other support
- 
- 
-Update Management {#updates}
-============================
-
-Change Log {#updates-changes}
--------------------------------------
-
-It is important to keep track of changes to the ACT Rules so that users of the rules can understand if changes in test results are due to changes in the rules used when performing the tests, or from changes in the content itself. All changes to an ACT Rule that can change the [=outcome=] of a evaluation MUST be recorded in a change log. The change log can either be part of the rule document itself or be referenced from it.
-
-Each new release of an ACT Rule MUST be identifiable with either a date or a version number. Additionally, a reference to the previous version of that rule MUST be available. For extensive changes, a new rule SHOULD be created and the old rule SHOULD be deprecated.
-
-<div class=example>
-  **Example**: An example of when a new rule ought to be created is when a rule that tests for the use of a `blink` element changes to instead look for any animated style changes. This potentially adds several new failures that were previously out of scope. Using that same rule as an example, adding an exception to allow `blink` elements positioned off screen can be done by updating the existing rule.
-</div>
 
 
-Issues List {#updates-issues}
+Background {#background}
+-----------------------
+An ACT Rule can contain information about the background for the development of the rule, or references to relevant reading. The relationship to the relevant reading should be specified. Examples of relevant background references for a rule for a WCAG [[WCAG]] success criterion could be [Understanding documents](https://www.w3.org/WAI/WCAG21/Understanding/), [WCAG Techniques](https://www.w3.org/WAI/WCAG21/Techniques/), or WAI-ARIA [[WAI-ARIA]], CSS [[CSS]], or HTML [[HTML]] specifications.
+
+
+Issues List {#issues-list}
 -------------------------------------
 
 An ACT Rule MAY include an issues list. When included, the issues list MUST be used to record cases when the [=outcome=] of an ACT Rule was `failed` where it ought to have been `passed`, or vice versa. There are several reasons why this might occur, including:

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -298,7 +298,7 @@ Content can be designed to rely on the support for particular accessibility feat
  
 An ACT Rule MUST include known limitations on accessibility support. For example, an atomic rule that checks for a particular accessibility feature that is known not to be widely supported by assistive technologies and web browsers, or a composite rule that includes atomic rules with known accessibility support limitations.
 
-While this item MUST be included in the ACT Rule, it MAY be empty.
+While this item MUST be included in the ACT Rule, it MAY be empty when there are no known accessibility support issues.
  
 <div class=note>
   **Note:** WCAG Evaluation Methodology (WCAG-EM) provides guidance on defining an [accessibility support baseline](https://www.w3.org/TR/WCAG-EM/#step1c) for test scenarios, which can help users of ACT Rules to select the appropriate rules for their own circumstance.
@@ -334,7 +334,7 @@ An ACT Rule MUST include a list or a reference to a list of any known issues. Th
 
 The issues list serves two purposes. For users of ACT Rules, the issues list gives insight into why an inaccurate result occurred, as well as provide confidence in the result of that rule. For the designer of the rule, the issues list is also useful to plan future updates to the rule. In a new version of the rule, resolved issues would be moved to the change log.
 
-While this item MUST be included in the ACT Rule document, it MAY be empty.
+While this item MUST be included in the ACT Rule document, it MAY be empty when there are no known issues.
 
 Acknowledgements (optional) {#acknowledgements}
 ===============================================

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -131,7 +131,7 @@ An ACT Rule SHOULD list an identifier and reference for each accessibility requi
 
 One reason why an [=atomic rule=] might not list accessibility requirements is because it is part of a [=composite rule=], and only a `failed` [=outcome=] in the composite rule would mean not satisfying the accessibility requirement. Another reason might be that an ACT Rule is designed to evaluate a best practice that is not part of any accessibility standard.
 
-This section can be left blank.
+This section MAY be left blank.
 
 Accessibility Requirements Mapping {#accessibility-requirements-mapping}
 ------------------------------------------------------------------------
@@ -292,7 +292,7 @@ An ACT Rule MUST list any assumptions, limitations or any exceptions for the eva
 
 Sometimes there are multiple plausible ways that an accessibility requirement can be interpreted. For instance, it is not immediately obvious if emoji characters are "text" or "non-text content" under WCAG 2.1. Whatever the interpretation is, this MUST be documented in the rule.
 
-This section can be left blank.
+This section MAY be left blank.
 
 Accessibility Support {#accessibility-support}
 ==============================================
@@ -300,7 +300,7 @@ Content can be designed to rely on the support for particular accessibility feat
  
 An ACT Rule MUST include known limitations on accessibility support. For example, an atomic rule that checks for a particular accessibility feature that is known not to be widely supported by assistive technologies and web browsers, or a composite rule that includes atomic rules with known accessibility support limitations.
 
-This section can be left blank.
+This section MAY be left blank.
  
 <div class=note>
   **Note:** WCAG Evaluation Methodology (WCAG-EM) provides guidance on defining an [accessibility support baseline](https://www.w3.org/TR/WCAG-EM/#step1c) for test scenarios, which can help users of ACT Rules to select the appropriate rules for their own circumstance.

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -323,18 +323,16 @@ Each new release of an ACT Rule MUST be identifiable with either a date or a ver
 </div>
 
 
-Issues List {#issues-list}
+Issues List (optional) {#issues-list}
 =====================================
 
-An ACT Rule MUST include a list or a reference to a list of any known issues. The issues list MUST be used to record cases where the [=outcome=] of an ACT Rule was `failed` where it ought to have been `passed` or `inapplicable`, or vice versa. There are several reasons why this might occur, including:
+An ACT Rule MAY include a list or a reference to a list of any known issues. The issues list would be used to record cases where the [=outcome=] of an ACT Rule was `failed` where it ought to have been `passed` or `inapplicable`, or vice versa. There are several reasons why this might occur, including:
 
 - Certain scenarios or the use of technologies that are very rare and were not included in the rule for that reason.
 - Certain accessibility features are impossible to test within the test environment. For instance, they might only be testable by accessing the accessibility API, require screen capturing, etc.
 - The scenario did not exist (due to changing technologies) or was overlooked during the initial design of the rule.
 
 The issues list serves two purposes. For users of ACT Rules, the issues list gives insight into why an inaccurate result occurred, as well as provide confidence in the result of that rule. For the designer of the rule, the issues list is also useful to plan future updates to the rule. In a new version of the rule, resolved issues would be moved to the change log.
-
-While this item MUST be included in the ACT Rule document, it MAY be empty when there are no known issues.
 
 Acknowledgements (optional) {#acknowledgements}
 ===============================================

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -73,7 +73,7 @@ An ACT Rule MUST consist of the following items:
 * [Test Cases](#test-cases)
 * ACT Rules Format [=outcome=] definition
 
-An ACT Rule MAY include one or more of the following [optional items](#optional-items)
+An ACT Rule MAY include one or more of the following [optional items](#optional-items):
  
 * Accessibility Support {#accessibility-support} (optional)
 * Background {#Background} (optional)

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -296,7 +296,7 @@ Accessibility Support {#accessibility-support}
 ==============================================
 Content can be designed to rely on the support for particular accessibility features by different assistive technologies and user agents. For example, content using a particular WAI-ARIA [[WAI-ARIA]] feature relies on that feature to be supported by assistive technologies and user agents. This content would not work for assistive technologies and user agents that do not support WAI-ARIA. WCAG [[WCAG]] provides a definition for [accessibility supported](https://www.w3.org/TR/WCAG20/#accessibility-supporteddef) use of a Web technology.
  
-An ACT Rule SHOULD include known limitations on accessibility support. For example, an atomic rule that checks for a particular accessibility feature that is known not to be widely supported by assistive technologies and web browsers, or a composite rule that includes atomic rules with known accessibility support limitations.
+An ACT Rule MUST include known limitations on accessibility support. For example, an atomic rule that checks for a particular accessibility feature that is known not to be widely supported by assistive technologies and web browsers, or a composite rule that includes atomic rules with known accessibility support limitations.
  
 <div class=note>
   **Note:** WCAG Evaluation Methodology (WCAG-EM) provides guidance on defining an [accessibility support baseline](https://www.w3.org/TR/WCAG-EM/#step1c) for test scenarios, which can help users of ACT Rules to select the appropriate rules for their own circumstance.
@@ -322,9 +322,9 @@ Each new release of an ACT Rule MUST be identifiable with either a date or a ver
 
 
 Issues List (optional) {#issues-list}
-==========================
+=====================================
 
-An ACT Rule MAY include an issues list. When included, the issues list MUST be used to record cases when the [=outcome=] of an ACT Rule was `failed` where it ought to have been `passed`, or vice versa. There are several reasons why this might occur, including:
+An ACT Rule MUST include a list or a reference to a list of any known issues. The issues list MUST be used to record cases where the [=outcome=] of an ACT Rule was `failed` where it ought to have been `passed` or `inapplicable`, or vice versa. There are several reasons why this might occur, including:
 
 - Certain scenarios or the use of technologies that are very rare and were not included in the rule for that reason.
 - Certain accessibility features are impossible to test within the test environment. For instance, they might only be testable by accessing the accessibility API, require screen capturing, etc.
@@ -334,17 +334,17 @@ The issues list serves two purposes. For users of ACT Rules, the issues list giv
 
 
 Acknowledgements (optional) {#acknowledgements}
-====================================
+===============================================
 
-An ACT Rule can contain acknowledgements. This may include, but is not limited to:
+An ACT Rule MAY contain acknowledgements. This may include, but is not limited to:
 * List of rule authors
 * List of rule reviewers/contributors
 * Funding or other support
 
 
 Background (optional) {#background}
-========================
-An ACT Rule can contain information about the background for the development of the rule, or references to relevant reading. The relationship to the relevant reading should be specified. Examples of relevant background references for a rule for a WCAG [[WCAG]] success criterion could be [Understanding documents](https://www.w3.org/WAI/WCAG21/Understanding/), [WCAG Techniques](https://www.w3.org/WAI/WCAG21/Techniques/), or WAI-ARIA [[WAI-ARIA]], CSS [[CSS]], or HTML [[HTML]] specifications.
+===================================
+An ACT Rule MAY contain information about the background for the development of the rule, or references to relevant reading. The relationship to the relevant reading should be specified. Examples of relevant background references for a rule for a WCAG [[WCAG]] success criterion could be [Understanding documents](https://www.w3.org/WAI/WCAG21/Understanding/), [WCAG Techniques](https://www.w3.org/WAI/WCAG21/Techniques/), or WAI-ARIA [[WAI-ARIA]], CSS [[CSS]], or HTML [[HTML]] specifications.
 
 
 Rule Accuracy {#accuracy}

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -59,27 +59,27 @@ Not all atomic rules have to be part of a composite rule. Composite rules are us
 ACT Rule Structure {#act-rule-structure}
 ===============================
 
-An ACT Rule MUST consist of the following items:
+An ACT Rule MUST consist of at least the following items:
 
 * Descriptive Title
 * [Rule Identifier](#rule-identifier)
 * [Rule Description](#rule-description)
 * [Rule type](#rule-types)
-* [Accessibility Requirements](#accessibility-requirements), if any
+* [Accessibility Requirements](#accessibility-requirements)
 * [Aspects Under Test](#input-aspects) (for atomic rules) OR [Atomic Rules List](#atomic-rules-list) (for composite rules)
 * [Applicability](#applicability)
 * [Expectations](#expectations)
-* [Assumptions](#assumptions), if any
+* [Assumptions](#assumptions)
+* [Accessibility Support](#accessibility-support)
 * [Test Cases](#test-cases)
 * [Change Log](#change-log)
 * ACT Rules Format [=outcome=] definition
 
 An ACT Rule MAY include one or more of the following [optional items](#optional-items):
- 
-* [Accessibility Support](#accessibility-support) (optional)
+
 * [Acknowledgements](#acknowledgements) (optional)
 * [Background](#background) (optional)
-* [Issues List](#issues-list)
+* [Issues List](#issues-list) (optional)
 
 ACT Rules MUST be written in a format that conforms to the Web Content Accessibility Guidelines [[WCAG]] or a comparable accessibility standard. ACT Rule [test cases](#test-cases) are allowed to contain inaccessible content. If any test case contains accessibility issues listed in [WCAG 2.1 Section 5.2.5 Non-Interference](https://www.w3.org/TR/WCAG21/#cc5), users MUST be warned of this in advance. Using an accessible format supports people with disabilities. It also makes internationalization of ACT Rules easier.
 
@@ -295,6 +295,17 @@ An ACT Rule MUST list any assumptions, limitations or any exceptions for the eva
 Sometimes there are multiple plausible ways that an accessibility requirement can be interpreted. For instance, it is not immediately obvious if emoji characters are "text" or "non-text content" under WCAG 2.1. Whatever the interpretation is, this MUST be documented in the rule.
 
 
+Accessibility Support {#accessibility-support}
+==============================================
+Content can be designed to rely on the support for particular accessibility features by different assistive technologies and user agents. For example, content using a particular WAI-ARIA [[WAI-ARIA]] feature relies on that feature to be supported by assistive technologies and user agents. This content would not work for assistive technologies and user agents that do not support WAI-ARIA. WCAG [[WCAG]] provides a definition for [accessibility supported](https://www.w3.org/TR/WCAG20/#accessibility-supporteddef) use of a Web technology.
+ 
+An ACT Rule SHOULD include known limitations on accessibility support. For example, an atomic rule that checks for a particular accessibility feature that is known not to be widely supported by assistive technologies and web browsers, or a composite rule that includes atomic rules with known accessibility support limitations.
+ 
+<div class=note>
+  **Note:** WCAG Evaluation Methodology (WCAG-EM) provides guidance on defining an [accessibility support baseline](https://www.w3.org/TR/WCAG-EM/#step1c) for test scenarios, which can help users of ACT Rules to select the appropriate rules for their own circumstance.
+</div>
+
+
 Test Cases {#test-cases}
 ========================
 
@@ -302,7 +313,7 @@ Test cases are (snippets of) content that can be used to validate the implementa
 
 
 Change Log {#change-log}
-=============================
+========================
 
 It is important to keep track of changes to the ACT Rules so that users of the rules can understand if changes in test results are due to changes in the rules used when performing the tests, or from changes in the content itself. All changes to an ACT Rule that can change the [=outcome=] of a evaluation MUST be recorded in a change log. The change log can either be part of the rule document itself or be referenced from it.
 
@@ -313,39 +324,8 @@ Each new release of an ACT Rule MUST be identifiable with either a date or a ver
 </div>
 
 
-Optional items {#optional-items}
-================================
-
-An ACT Rule can contain additional information that is useful, but not critical, for the reader to understand the background and context of a rule, or any information that is relevant. This can include, but is not limited to, one or more of the following:
-
-
-Accessibility Support {#accessibility-support}
-----------------------------------------------
-Content can be designed to rely on the support for particular accessibility features by different assistive technologies and user agents. For example, content using a particular WAI-ARIA [[WAI-ARIA]] feature relies on that feature to be supported by assistive technologies and user agents. This content would not work for assistive technologies and user agents that do not support WAI-ARIA. WCAG [[WCAG]] provides a definition for [accessibility supported](https://www.w3.org/TR/WCAG20/#accessibility-supporteddef) use of a Web technology.
- 
-An ACT Rule SHOULD include known limitations on accessibility support. For example, an atomic rule that checks for a particular accessibility feature that is known not to be widely supported by assistive technologies and web browsers, or a composite rule that includes atomic rules with known accessibility support limitations.
- 
-<div class=note>
-  **Note:** WCAG Evaluation Methodology (WCAG-EM) provides guidance on defining an [accessibility support baseline](https://www.w3.org/TR/WCAG-EM/#step1c) for test scenarios, which can help users of ACT Rules to select the appropriate rules for their own circumstance.
-</div>
-
-
-Acknowledgements {#acknowledgements}
-------------------------------------
-
-An ACT Rule can contain acknowledgements. This may include, but is not limited to:
-* List of rule authors
-* List of rule reviewers/contributors
-* Funding or other support
-
-
-Background {#background}
------------------------
-An ACT Rule can contain information about the background for the development of the rule, or references to relevant reading. The relationship to the relevant reading should be specified. Examples of relevant background references for a rule for a WCAG [[WCAG]] success criterion could be [Understanding documents](https://www.w3.org/WAI/WCAG21/Understanding/), [WCAG Techniques](https://www.w3.org/WAI/WCAG21/Techniques/), or WAI-ARIA [[WAI-ARIA]], CSS [[CSS]], or HTML [[HTML]] specifications.
-
-
-Issues List {#issues-list}
--------------------------------------
+Issues List (optional) {#issues-list}
+==========================
 
 An ACT Rule MAY include an issues list. When included, the issues list MUST be used to record cases when the [=outcome=] of an ACT Rule was `failed` where it ought to have been `passed`, or vice versa. There are several reasons why this might occur, including:
 
@@ -354,6 +334,20 @@ An ACT Rule MAY include an issues list. When included, the issues list MUST be u
 - The scenario did not exist (due to changing technologies) or was overlooked during the initial design of the rule.
 
 The issues list serves two purposes. For users of ACT Rules, the issues list gives insight into why an inaccurate result occurred, as well as provide confidence in the result of that rule. For the designer of the rule, the issues list is also useful to plan future updates to the rule. In a new version of the rule, resolved issues would be moved to the change log.
+
+
+Acknowledgements (optional) {#acknowledgements}
+====================================
+
+An ACT Rule can contain acknowledgements. This may include, but is not limited to:
+* List of rule authors
+* List of rule reviewers/contributors
+* Funding or other support
+
+
+Background (optional) {#background}
+========================
+An ACT Rule can contain information about the background for the development of the rule, or references to relevant reading. The relationship to the relevant reading should be specified. Examples of relevant background references for a rule for a WCAG [[WCAG]] success criterion could be [Understanding documents](https://www.w3.org/WAI/WCAG21/Understanding/), [WCAG Techniques](https://www.w3.org/WAI/WCAG21/Techniques/), or WAI-ARIA [[WAI-ARIA]], CSS [[CSS]], or HTML [[HTML]] specifications.
 
 
 Rule Accuracy {#accuracy}

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -344,6 +344,7 @@ An ACT Rule MAY contain acknowledgements. This may include, but is not limited t
 
 Background (optional) {#background}
 ===================================
+
 An ACT Rule MAY contain information about the background for the development of the rule, or references to relevant reading. The relationship to the relevant reading should be specified. Examples of relevant background references for a rule for a WCAG [[WCAG]] success criterion could be [Understanding documents](https://www.w3.org/WAI/WCAG21/Understanding/), [WCAG Techniques](https://www.w3.org/WAI/WCAG21/Techniques/), or WAI-ARIA [[WAI-ARIA]], CSS [[CSS]], or HTML [[HTML]] specifications.
 
 

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -301,7 +301,7 @@ Test Cases {#test-cases}
 Test cases are (snippets of) content that can be used to validate the implementation of ACT Rules. Each rule MUST have one or more test cases for `passed`, `failed`, and `inapplicable` [=outcome=]. A test case consists of two pieces of data, a snippet of each [test aspect](#input-aspects) for a rule, and the expected result from evaluating that rule. Test cases serve two functions, firstly as example scenarios for readers to understand when a rule passes, when it fails, and when it is inapplicable. It also serves developers and users of accessibility testing tools and methodologies to validate that a rule is correctly implemented.
 
 
-Change Log {#changes-log}
+Change Log {#change-log}
 =============================
 
 It is important to keep track of changes to the ACT Rules so that users of the rules can understand if changes in test results are due to changes in the rules used when performing the tests, or from changes in the content itself. All changes to an ACT Rule that can change the [=outcome=] of a evaluation MUST be recorded in a change log. The change log can either be part of the rule document itself or be referenced from it.

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -73,13 +73,10 @@ An ACT Rule MUST consist of at least the following items:
 * [Accessibility Support](#accessibility-support)
 * [Test Cases](#test-cases)
 * [Change Log](#change-log)
-* ACT Rules Format [=outcome=] definition
-
-An ACT Rule MAY include one or more of the following [optional items](#optional-items):
-
+* [Issues List](#issues-list) (optional)
 * [Acknowledgements](#acknowledgements) (optional)
 * [Background](#background) (optional)
-* [Issues List](#issues-list) (optional)
+* ACT Rules Format [=outcome=] definition
 
 ACT Rules MUST be written in a format that conforms to the Web Content Accessibility Guidelines [[WCAG]] or a comparable accessibility standard. ACT Rule [test cases](#test-cases) are allowed to contain inaccessible content. If any test case contains accessibility issues listed in [WCAG 2.1 Section 5.2.5 Non-Interference](https://www.w3.org/TR/WCAG21/#cc5), users MUST be warned of this in advance. Using an accessible format supports people with disabilities. It also makes internationalization of ACT Rules easier.
 


### PR DESCRIPTION
Based on discussion of https://github.com/w3c/wcag-act/issues/293


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/annethyme/wcag-act/pull/305.html" title="Last updated on Nov 29, 2018, 11:03 PM GMT (4bf90aa)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/305/809e9f5...annethyme:4bf90aa.html" title="Last updated on Nov 29, 2018, 11:03 PM GMT (4bf90aa)">Diff</a>