### PR TITLE
added Exit Criteria

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -738,3 +738,92 @@ The following updates have been made since the last public working draft:
   <li>Added an acknowledgements section to acknowledge contributors to the ACT Rules Format.</li>
 </ul>
 <p>All changes from the previous published version can be viewed using the [July 2018 to February 2019 diff link](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FTR%2Fact-rules-format%2F&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fw3c%2Fwcag-act%2Fpull%2F328.html)</p>
+
+
+Appendix 4: Exit Criteria {#Exit_Criteria}
+==========================
+
+General
+-------
+
+* [C1] All rules must conform to the ACT Rules Format
+
+Accessibility requirements mapping
+----------------------------------
+
+Each rule implemented in plain English form, as listed below:
+* [C2] At least one atomic rule that has a requirement in WCAG 2
+* [C3] At least one composite rule that has a requirement in WCAG 2
+* [C4] At least one rule that is a satisfying test, and one rule that is not
+* [C5] At least one rule that has a accessibility requirement that is not part of WCAG
+* [C6] At least one atomic rule has no accessibility requirement, but is used in a composite rule that has a requirement in WCAG 2
+
+Rule Input
+----------
+
+* [C7] At least two different input aspects are used
+* [C8] At least two different web content technologies
+
+Applicability
+-------------
+
+* [C9] At least one atomic rule has an applicability different from the composite rule it is used in
+
+Expectations
+------------
+
+* [C10] At least one rule with one expectation
+* [C11] At least one rule with more than one expectation
+
+Assumptions
+-----------
+
+* [C12] At least one rule without assumptions
+* [C13] At least one rule where exceptions are documented in an assumption
+* [C14] At least one rule where interpretation is documented in an assumption
+
+Accessibility Support
+---------------------
+
+* [C15] At least one rule where no accessibility support information was necessary
+* [C16] At least one rule where accessibility support information was included
+
+Changelog
+---------
+
+* [C17] At least two rules that include a changelog
+
+Glossary
+--------
+
+* [C18] At least two rules with more than one definition
+
+Issues list
+-----------
+
+* [C19] At least two rules that include an issues list
+
+Test cases
+----------
+
+* [C20] Every applicability must have at least one inapplicable test case
+* [C21] Every expectation must have at least one pass and one fail test case
+
+Background
+----------
+
+* [C22] At least two rules with a background section
+
+Acknowledgements
+----------------
+
+* [C23] At least two rules with an acknowledgements section
+
+Implementations and data format
+-------------------------------
+
+* [C24] At least two fully automated independent implementations of the same ACT rule
+   (All test cases that should pass are passing, all test cases that should fail are failing)  
+* [C25] At least two semi-automated independent implementations of the same ACT rule
+   (Some results running against test cases are inconclusive, none of the results contradict the test cases)  
+* [C26] At least two independent implementations of the same ACT rule in manual testing methodologies


### PR DESCRIPTION
Moved [Exit Criteria from wiki](https://www.w3.org/WAI/GL/task-forces/conformance-testing/wiki/Exit_Criteria_for_Rules_Format_Spec), which have been approved by the TF/WG, to this appendix so that it is within the same document for publication.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/pull/352.html" title="Last updated on Mar 29, 2019, 5:09 PM UTC (0e19f39)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/352/1de230e...0e19f39.html" title="Last updated on Mar 29, 2019, 5:09 PM UTC (0e19f39)">Diff</a>