### PR TITLE
Optional items under must

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -83,7 +83,7 @@ An ACT Rule MUST consist of at least the following items:
 * [Change Log](#change-log)
 * [Glossary](#glossary)
 
-An ACT Rule can also contain:
+An ACT Rule MAY also contain:
 
 * [Issues List](#issues-list) (optional)
 * [Background](#background) (optional)

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -82,6 +82,9 @@ An ACT Rule MUST consist of at least the following items:
 * [Test Cases](#test-cases)
 * [Change Log](#change-log)
 * [Glossary](#glossary)
+
+An ACT Rule could also contain:
+
 * [Issues List](#issues-list) (optional)
 * [Background](#background) (optional)
 * [Acknowledgements](#acknowledgements) (optional)

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -83,7 +83,7 @@ An ACT Rule MUST consist of at least the following items:
 * [Change Log](#change-log)
 * [Glossary](#glossary)
 
-An ACT Rule could also contain:
+An ACT Rule can also contain:
 
 * [Issues List](#issues-list) (optional)
 * [Background](#background) (optional)


### PR DESCRIPTION
Added in "An ACT Rule can also contain" before the optional parts.  Used "can" because I wasn't sure if I was allowed to add in normative language like "MAY" when we're in CR status. See Issue #357.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/pull/382.html" title="Last updated on Jun 17, 2019, 2:34 PM UTC (3e09740)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/382/4678ff3...3e09740.html" title="Last updated on Jun 17, 2019, 2:34 PM UTC (3e09740)">Diff</a>