### PR TITLE
Fix "rule type" link in section 4

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -70,7 +70,7 @@ An ACT Rule MUST consist of at least the following items:
 * <dfn>Descriptive Title</dfn>
 * [Rule Identifier](#rule-identifier)
 * [Rule Description](#rule-description)
-* [Rule Type](#rule-types)
+* [Rule Type](#rule-type)
 * [Accessibility Requirements Mapping](#accessibility-requirements-mapping)
 * [Rule Input](#input), which is one of the following:
     * [Input Aspects](#input-aspects) (for atomic rules) OR


### PR DESCRIPTION
Have "rule type" from section 4 link to section 4.3, rather than link back up to section 3.

Issue #375


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/pull/387.html" title="Last updated on Jun 27, 2019, 2:53 PM UTC (ce394cb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/387/4678ff3...ce394cb.html" title="Last updated on Jun 27, 2019, 2:53 PM UTC (ce394cb)">Diff</a>