### PR TITLE
fixed link

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -429,7 +429,7 @@ While the assumptions <em class="rfc2119">must</em> be included in the ACT Rule,
 Accessibility Support {#accessibility-support}
 ----------------------------------------------
 
-Content can be designed to rely on the support for particular accessibility features by different assistive technologies and user agents. For example, content using a particular [WAI-ARIA 1.1](https://www.w3.org/TR/wai-aria/) feature relies on that feature to be supported by assistive technologies and user agents. This content would not work for assistive technologies and user agents that do not support WAI-ARIA. See the WCAG definition for [accessibility supported](https://www.w3.org/TR/WCAG21/#accessibility-supporteddef) use of a web technology.
+Content can be designed to rely on the support for particular accessibility features by different assistive technologies and user agents. For example, content using a particular [WAI-ARIA 1.1](https://www.w3.org/TR/wai-aria/) feature relies on that feature to be supported by assistive technologies and user agents. This content would not work for assistive technologies and user agents that do not support WAI-ARIA. See the WCAG definition for [accessibility supported](https://www.w3.org/TR/WCAG21/#dfn-accessibility-supported) use of a web technology.
 
 An ACT Rule <em class="rfc2119">must</em> include known limitations on accessibility support.
 


### PR DESCRIPTION
Accessibility Support: fixed link to definition of "Accessibility Supported" in WCAG (anchor name changed from 2.0 to 2.1)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/pull/401.html" title="Last updated on Jul 17, 2019, 4:14 PM UTC (a885893)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/401/e5e24e1...a885893.html" title="Last updated on Jul 17, 2019, 4:14 PM UTC (a885893)">Diff</a>