### PR TITLE
fixed broken link

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -419,7 +419,7 @@ All expectations of a [=composite rule=] <em class="rfc2119">must</em> describe 
 Assumptions {#assumptions}
 --------------------------
 
-An ACT Rule <em class="rfc2119">must</em> list any known assumptions, limitations or any exceptions for the evaluation, the test environment, technologies being used or the subject being tested. For example, a rule that would partially test [WCAG 2.1 success criterion 1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/quickref/#visual-audio-contrast-contrast) based on the inspection of CSS properties could state that it is only applicable to HTML text content styleable with CSS, and that the rule does not support images of text.
+An ACT Rule <em class="rfc2119">must</em> list any known assumptions, limitations or any exceptions for the evaluation, the test environment, technologies being used or the subject being tested. For example, a rule that would partially test [WCAG 2.1 success criterion 1.4.3 Contrast (Minimum)](https://www.w3.org/WAI/WCAG21/quickref/#contrast-minimum) based on the inspection of CSS properties could state that it is only applicable to HTML text content styleable with CSS, and that the rule does not support images of text.
 
 Sometimes there are multiple plausible ways that an accessibility requirement can be interpreted. For instance, it is not immediately obvious if emoji characters are "text" or "non-text content" in the [Web Content Accessibility Guidelines](https://www.w3.org/WAI/standards-guidelines/wcag/) [[WCAG]]. Whatever the interpretation is, this <em class="rfc2119">must</em> be documented in the rule.
 


### PR DESCRIPTION
Assumptions: fixed link to QuickRef "WCAG 2.1 success criterion 1.4.3 Contrast" (anchor name changed from WCAG 2.0 to 2.1)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/pull/403.html" title="Last updated on Jul 17, 2019, 4:18 PM UTC (e705195)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/403/e5e24e1...e705195.html" title="Last updated on Jul 17, 2019, 4:18 PM UTC (e705195)">Diff</a>