### PR TITLE
fix typos identified by David McDonald

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -126,7 +126,7 @@ An ACT Rule <em class="rfc2119">must</em> have an identifier. This identifier <e
   </ul></blockquote>
 </aside>
 
-In addition to the identifier, each new release of an ACT Rule <em class="rfc2119">must</em> be versioned with either a date or a number. A reference to the previous version of that rule <em class="rfc2119">must</em> be available. The identifier <em class="rfc2119">must nost</em> be changed when the rule is updated. For substantial changes, a new rule <em class="rfc2119">should</em> be created with a new identifier, and the old rule <em class="rfc2119">should</em> be deprecated.
+In addition to the identifier, each new release of an ACT Rule <em class="rfc2119">must</em> be versioned with either a date or a number. A reference to the previous version of that rule <em class="rfc2119">must</em> be available. The identifier <em class="rfc2119">must not</em> be changed when the rule is updated. For substantial changes, a new rule <em class="rfc2119">should</em> be created with a new identifier, and the old rule <em class="rfc2119">should</em> be deprecated.
 
 <aside class=example>
   <header>Example situation of updating a rule:</header>
@@ -434,7 +434,7 @@ Content can be designed to rely on the support for particular accessibility feat
 An ACT Rule <em class="rfc2119">must</em> include known limitations on accessibility support.
 
 <aside class=example>
-  <header>Example of a rule that checks if `aria-errormessage` is used satisfy [WCAG 2.1 success criterion 4.1.3 Status messages](https://www.w3.org/TR/WCAG21/#status-messages):<header>
+  <header>Example of a rule that checks if `aria-errormessage` is used to satisfy [WCAG 2.1 success criterion 4.1.3 Status messages](https://www.w3.org/TR/WCAG21/#status-messages):<header>
   <blockquote><p>
     The `aria-errormessage` property is known to have limited support with several major screen readers. This method cannot be relied on for support. Alternatives, like using live regions, could serve as fallback. (January 2019)
   </p></blockquote>


### PR DESCRIPTION
Editorial [comments from David McDonald](https://lists.w3.org/Archives/Public/w3c-wai-gl/2019JulSep/0048.html):

> MUST NOST
> should be "MUST NOT"
> 
> 4.8
> Example of a  rule that checks if aria-errormessage is used <add>to</add> satisfy WCAG 2.1 success criterion 4.1.3 Status messages :


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/pull/404.html" title="Last updated on Jul 18, 2019, 9:32 AM UTC (8973bf8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/404/e5e24e1...8973bf8.html" title="Last updated on Jul 18, 2019, 9:32 AM UTC (8973bf8)">Diff</a>