### PR TITLE
fixing validation error

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -434,7 +434,7 @@ Content can be designed to rely on the support for particular accessibility feat
 An ACT Rule <em class="rfc2119">must</em> include known limitations on accessibility support.
 
 <aside class=example>
-  <header>Example of a rule that checks if `aria-errormessage` is used to satisfy [WCAG 2.1 success criterion 4.1.3 Status messages](https://www.w3.org/TR/WCAG21/#status-messages):<header>
+  <header>Example of a rule that checks if `aria-errormessage` is used to satisfy [WCAG 2.1 success criterion 4.1.3 Status messages](https://www.w3.org/TR/WCAG21/#status-messages):</header>
   <blockquote><p>
     The `aria-errormessage` property is known to have limited support with several major screen readers. This method cannot be relied on for support. Alternatives, like using live regions, could serve as fallback. (January 2019)
   </p></blockquote>


### PR DESCRIPTION
changed wrong <header> to </header> in the example in "Accessibility Support"


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/pull/409.html" title="Last updated on Jul 22, 2019, 3:21 PM UTC (ce5f168)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/409/eb7eae8...ce5f168.html" title="Last updated on Jul 22, 2019, 3:21 PM UTC (ce5f168)">Diff</a>