### PR TITLE
fixed link to Common Input Aspects WG Note

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -276,7 +276,7 @@ An input aspect is a distinct part of the [=test subject=]. Rendering a particul
 
 [=Atomic rules=] <em class="rfc2119">must</em> list the aspects used as input for the [applicability](#applicability-atomic) and [expectations](#expectations-atomic) of the atomic rule. Rules can operate on several aspects simultaneously, such as both the HTTP messages and the DOM tree.
 
-Some input aspects are well defined in a formal specification, such as HTTP messages, the DOM tree, and CSS styling [[css-2018]]. For these, a reference to the corresponding section in the [Common Input Aspects note](https://w3c.github.io/wcag-act/NOTE-act-rules-common-aspects.html) is sufficient as a description of the aspect. For input aspects that are not well defined, an ACT Rule <em class="rfc2119">must</em> include either a detailed description of the aspect in question, or a reference to a well defined description.
+Some input aspects are well defined in a formal specification, such as HTTP messages, the DOM tree, and CSS styling [[css-2018]]. For these, a reference to the corresponding section in the [Common Input Aspects note](https://www.w3.org/TR/act-rules-aspects/) is sufficient as a description of the aspect. For input aspects that are not well defined, an ACT Rule <em class="rfc2119">must</em> include either a detailed description of the aspect in question, or a reference to a well defined description.
 
 <aside class=example>
   <header>Example input aspects for a rule that checks if a transcript is available for videos:</header>


### PR DESCRIPTION
Closes #413 

Changed the link for Common Input Aspects WG Note in section 4.5.1 from Editor's Draft to Latest Published version.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/pull/415.html" title="Last updated on Aug 18, 2019, 11:31 AM UTC (30f013d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/415/a756dfc...30f013d.html" title="Last updated on Aug 18, 2019, 11:31 AM UTC (30f013d)">Diff</a>