### PR TITLE
editorial: fix inconsistency in accessibility requirement

### DIFF
--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -555,7 +555,7 @@ Definitions {#definitions}
 <dl>
   <dt><dfn>Accessibility requirement</dfn><dt>
   <dd>
-    <p>A requirement is a condition that has to be satisfied in order to conform to a standard, or to comply with a contract, policy or regulation. An accessibility requirement is a requirement aimed at improving access for people with disabilities to an ICT product.</p>
+    <p>A requirement is a condition that has to be satisfied in order to conform to a standard, or to comply with a contract, policy or regulation. A requirement can also be advisory, where it is recommended, but not satisfying it does not lead to non-conformance or non-compliance. An accessibility requirement is a requirement aimed at improving access for people with disabilities to an ICT product.<p>
     <p>A common example of accessibility requirements are the WCAG success criteria. There are other standards, including W3C standards, that have recommendations for accessibility, such as WAI-ARIA and HTML. Accessibility requirements are also often found in company policies, regional standards or in legislation.</p>
   </dd>
 

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -555,7 +555,7 @@ Definitions {#definitions}
 <dl>
   <dt><dfn>Accessibility requirement</dfn><dt>
   <dd>
-    <p>A requirement is a condition that has to be satisfied in order to conform to a standard, or to comply with a contract, policy or regulation. A requirement can also be advisory, where it is recommended, but not satisfying it does not lead to non-conformance or non-compliance. An accessibility requirement is a requirement aimed at improving access for people with disabilities to an ICT product.<p>
+    <p>An accessibility requirement is a requirement aimed at improving access for people with disabilities to an ICT product. In the context of ACT rules mapping, a requirement can be compulsory or advisory. When compulsory, it has to be satisfied in order to conform to a standard, or to comply with a contract, policy or regulation. When advisory, it is recommended, but not satisfying it does not lead to non-conformance or non-compliance.<p>
     <p>A common example of accessibility requirements are the WCAG success criteria. There are other standards, including W3C standards, that have recommendations for accessibility, such as WAI-ARIA and HTML. Accessibility requirements are also often found in company policies, regional standards or in legislation.</p>
   </dd>
 

--- a/act-rules-format.bs
+++ b/act-rules-format.bs
@@ -555,7 +555,7 @@ Definitions {#definitions}
 <dl>
   <dt><dfn>Accessibility requirement</dfn><dt>
   <dd>
-    <p>An accessibility requirement is a requirement aimed at improving access for people with disabilities to an ICT product. In the context of ACT rules mapping, a requirement can be compulsory or advisory. When compulsory, it has to be satisfied in order to conform to a standard, or to comply with a contract, policy or regulation. When advisory, it is recommended, but not satisfying it does not lead to non-conformance or non-compliance.<p>
+    <p>An accessibility requirement is a requirement aimed at improving access for people with disabilities to an ICT product. In the context of ACT rules mapping, a requirement can be compulsory or advisory. When compulsory, it has to be satisfied in order to conform to a standard, or to comply with a contract, policy or regulation. When advisory, it is recommended, but not satisfying it does not lead to non-conformance or non-compliance.</p>
     <p>A common example of accessibility requirements are the WCAG success criteria. There are other standards, including W3C standards, that have recommendations for accessibility, such as WAI-ARIA and HTML. Accessibility requirements are also often found in company policies, regional standards or in legislation.</p>
   </dd>
 


### PR DESCRIPTION
The current definition is inconsistent in how it is used. While the intent was to include best practices as accessibility requirements, the current reading does not allow for this. The ACT rules format mentions explicitly that these can be best practices, so the definition is incorrect. This should resolve the issue.

Closes #424


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/pull/450.html" title="Last updated on May 14, 2020, 1:29 PM UTC (d74f86a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wcag-act/450/627e269...d74f86a.html" title="Last updated on May 14, 2020, 1:29 PM UTC (d74f86a)">Diff</a>