### PR TITLE
Add note about language

### DIFF
--- a/NOTE-act-rules-common-aspects.bs
+++ b/NOTE-act-rules-common-aspects.bs
@@ -65,3 +65,5 @@ Language {#input-aspects-text}
 Language, either written or spoken, contained in nodes of the DOM [[DOM]] or accessibility trees may be of interest to ACT Rules that intend to test things like complexity or intention of the language. For example, an ACT Rule might test that paragraphs of text within the DOM tree do not exceed a certain readability score or that the text alternative of an image provides a sufficient description.
 
 The means by which the language is assessed, whether by a person or a machine, is not of importance as long as the assessment meets the criteria defined in [[wcag2-tech-req#humantestable]] [[WCAG]].
+
+Rules with a Language input aspect can only be evaluated if the language can be determined (either programatically or by analysing content), and sufficiently understood.


### PR DESCRIPTION
All rules with Language as input aspect currently have an assumption that the language is understood by the tester (so that, e.g., a tester can asses whether an accessible name is descriptive or not).
Moving this requirement here.