### PR TITLE
Fix w3c.json group

### DIFF
--- a/w3c.json
+++ b/w3c.json
@@ -1,5 +1,5 @@
 {
-  "group": "tf/wcag-act",
+  "group": "wg/ag",
   "contacts": [ "daniel-montalvo" ],
   "repo-type": "rec-track",
   "policy": "restricted" 


### PR DESCRIPTION
w3c.json expects a top-level group, not a task force identifier