### PR TITLE
Consistency: Prioritize cantTell over pass

### DIFF
--- a/act-rules-format/act-rules-format.bs
+++ b/act-rules-format/act-rules-format.bs
@@ -645,9 +645,9 @@ When a [=check=] reports more than one outcomes for a test case, the first outco
 
 1. `failed`
 2. `untested`
-3. `passed`
-4. `inapplicable`
-5. `cantTell`
+3. `cantTell`
+4. `passed`
+5. `inapplicable`
 
 ### Partial Consistency ### {#impl-partial-consistency}
 


### PR DESCRIPTION
Based on feedback @dbjorge: from https://github.com/w3c/wcag/issues/3616#issuecomment-1896487077


I agree that `cantTell` was too low down the list. If a check reports `pass` and `cantTell`, it's incorrect to conclude that's a pass. It wouldn't work for satisfying rules. I think it does not go above `untested` though. Any `untested` outcome should prevent a check from getting mapped as `consistent`, and if we put `cantTell` before `untested` that wouldn't happen; Checks can be consistent when they report `cantTell` as long as that isn't the only thing they report.