### PR TITLE
Update act-rules-format.bs

### DIFF
--- a/act-rules-format/act-rules-format.bs
+++ b/act-rules-format/act-rules-format.bs
@@ -135,7 +135,7 @@ The ACT Rules format does not prescribe what format ACT Rules can be written in 
 Rule Identifier {#rule-identifier}
 ----------------------------------
 
-An ACT Rule <em class="rfc2119">must</em> have an identifier that is a unique within its ruleset. The identifier can be any text, URL, a database identifier, etc..
+An ACT Rule <em class="rfc2119">must</em> have an identifier that is unique within its ruleset. The identifier can be any text, URL, a database identifier, etc.
 
 <aside class="example">
   <header>Identifiers that are also used as filenames; They include a technology directory, followed by a handle that includes an element name or attribute:</header>


### PR DESCRIPTION
Fixes two minor typos in 4.1.
- "that is a unique" should be "that is unique" (delete "a")
- extra period at end of sentence

Current:
> An ACT Rule _must_ have an identifier that is a unique within its ruleset. The identifier can be any text, URL, a database identifier, etc..

Proposted:
> An ACT Rule _must_ have an identifier that is unique within its ruleset. The identifier can be any text, URL, a database identifier, etc.